### PR TITLE
feat: Add acdc_source metadata to response.extra (Fixes #5)

### DIFF
--- a/doc/caching.md
+++ b/doc/caching.md
@@ -86,3 +86,22 @@ dio.streamRequest<Map<String, dynamic>>(
 ```
 
 **Note**: `streamRequest` automatically handles caching headers and logic. If the cache is missing or expired beyond the "stale" limit, it will only emit the network response.
+
+### Identifying Response Source
+
+You can inspect `response.extra['acdc_source']` to determine the exact source of a response:
+
+| Value | Description |
+| :--- | :--- |
+| `'cache'` | Standard cache hit. |
+| `'network'` | Standard network response (cache miss, skip, or refresh). |
+| `'cache_stale'` | **SWR**: The initial stale response emitted primarily from cache. |
+| `'network_fresh'` | **SWR**: The subsequent fresh response emitted from a background network refresh. |
+
+```dart
+if (response.extra['acdc_source'] == 'cache_stale') {
+  showBadge('STALE');
+} else if (response.extra['acdc_source'] == 'network_fresh') {
+  showBadge('FRESH');
+}
+```

--- a/lib/src/interceptors/cache_interceptor.dart
+++ b/lib/src/interceptors/cache_interceptor.dart
@@ -209,6 +209,7 @@ class AcdcCacheInterceptor extends Interceptor {
         // Serve stale cache immediately
         final response = cachedResponse.toResponse(options)..statusCode = 200;
         // Important: Update status code to 200, as it might be stored differently
+        response.extra['acdc_source'] = 'cache_stale';
 
         // Add metadata
         _addCacheMetadata(response);
@@ -331,6 +332,18 @@ class AcdcCacheInterceptor extends Interceptor {
     // Delegate to dio_cache_interceptor
     _dioCacheInterceptor.onResponse(response, handler);
 
+    // Determine and set acdc_source for network responses
+    // We only set this if it wasn't already set (e.g. by cache logic)
+    if (response.extra['acdc_source'] == null) {
+      final fromCache = response.extra['from_cache'] as bool? ?? false;
+      if (!fromCache) {
+        final isSwrRefresh =
+            response.requestOptions.extra['swr_refresh'] == true;
+        response.extra['acdc_source'] =
+            isSwrRefresh ? 'network_fresh' : 'network';
+      }
+    }
+
     // If response was not from cache, it is likely being written to cache
     // (dio_cache_interceptor handles logic, but if we got here, we are passing it down)
     final fromCache = response.extra['from_cache'] as bool? ?? false;
@@ -415,6 +428,7 @@ class AcdcCacheInterceptor extends Interceptor {
         final response = cachedResponse.toResponse(requestOptions)
           ..statusCode = 200;
 
+        response.extra['acdc_source'] = 'cache';
         _addCacheMetadata(response);
         return response;
       }
@@ -487,6 +501,7 @@ class _CacheAwareRequestHandler extends RequestInterceptorHandler {
     // This is called when dio_cache_interceptor finds a valid cache entry.
     // Mark the response as being from cache.
     response.extra['from_cache'] = true;
+    response.extra['acdc_source'] = 'cache';
     response.headers.add('X-ACDC-From-Cache', 'true');
 
     logDelegate?.log(
@@ -558,6 +573,7 @@ class _CacheAwareErrorHandler extends ErrorInterceptorHandler {
     // Add offline cache metadata
     response.extra['fromOfflineCache'] = true;
     response.extra['from_cache'] = true;
+    response.extra['acdc_source'] = 'cache';
     response.headers.add('X-ACDC-From-Cache', 'true');
 
     originalHandler.resolve(response);

--- a/test/interceptors/cache_interceptor_test.dart
+++ b/test/interceptors/cache_interceptor_test.dart
@@ -688,6 +688,132 @@ void main() {
         );
       });
     });
+    group('ACDC Source Metadata', () {
+      test('sets acdc_source to "network" for network responses', () async {
+        final interceptor = AcdcCacheInterceptor(
+          config: const CacheConfig(),
+          store: MemCacheStore(),
+        );
+
+        final dio = Dio();
+        dio.interceptors.add(interceptor);
+        dio.httpClientAdapter = MockAdapter((options) async {
+          return ResponseBody.fromString(
+            '{}',
+            200,
+            headers: {
+              Headers.contentTypeHeader: [Headers.jsonContentType],
+            },
+          );
+        });
+
+        final response = await dio.get<dynamic>('/network-only');
+        expect(response.extra['acdc_source'], 'network');
+      });
+
+      test('sets acdc_source to "cache" for standard cache hits', () async {
+        final store = MemCacheStore();
+        final interceptor = AcdcCacheInterceptor(
+          config: const CacheConfig(),
+          store: store,
+        );
+        final dio = Dio();
+        dio.interceptors.add(interceptor);
+
+        final headers = {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+          'cache-control': ['max-age=3600'],
+          'etag': ['123'],
+        };
+
+        dio.httpClientAdapter = MockAdapter((options) async {
+          return ResponseBody.fromString(
+            '{}',
+            200,
+            headers: headers,
+          );
+        });
+
+        // Seed cache
+        await dio.get<dynamic>('/cached-std');
+
+        // Hit cache
+        final response = await dio.get<dynamic>('/cached-std');
+        expect(response.extra['acdc_source'], 'cache');
+      });
+
+      test('integration: sets acdc_source for SWR flow (stale then fresh)',
+          () async {
+        final dio = Dio();
+        final store = MemCacheStore();
+
+        // We need the refresh to actually go through the interceptor to get tagged 'network_fresh'.
+        final interceptor = AcdcCacheInterceptor(
+          config: const CacheConfig(staleWhileRevalidate: true),
+          store: store,
+          onRefresh: (options) => dio.fetch<dynamic>(options),
+        );
+        dio.interceptors.add(interceptor);
+
+        final headers = {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+          'cache-control': ['max-age=3600'],
+          'etag': ['123'],
+        };
+
+        dio.httpClientAdapter = MockAdapter((options) async {
+          // If refreshing, return distinct fresh data
+          if (options.extra['swr_refresh'] == true) {
+            return ResponseBody.fromString(
+              '{"val": "fresh"}',
+              200,
+              headers: headers,
+            );
+          }
+          return ResponseBody.fromString(
+            '{"val": "stale"}',
+            200,
+            headers: headers,
+          );
+        });
+
+        const path = 'https://api.example.com/swr-test';
+
+        // 1. Seed (Network Miss -> 'network')
+        var response = await dio.get<dynamic>(path);
+        expect(response.data['val'], 'stale');
+        expect(response.extra['acdc_source'], 'network');
+
+        // 2. SWR Hit (Stale -> 'cache_stale') + Background Refresh -> 'network_fresh'
+        Future<dynamic>? bgFuture;
+        final responseSWR = await dio.get<dynamic>(
+          path,
+          options: Options(
+            extra: {
+              'swr_callback': (Future<dynamic> f) => bgFuture = f,
+            },
+          ),
+        );
+
+        // Check immediate response (Stale)
+        expect(responseSWR.data['val'], 'stale');
+        expect(responseSWR.extra['acdc_source'], 'cache_stale');
+
+        // Wait for background refresh
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        expect(
+          bgFuture,
+          isNotNull,
+          reason: 'Background refresh should have been triggered',
+        );
+
+        final refreshResponse = await bgFuture;
+        expect(refreshResponse, isA<Response>());
+        // Check refresh response (Fresh)
+        expect((refreshResponse as Response).data['val'], 'fresh');
+        expect(refreshResponse.extra['acdc_source'], 'network_fresh');
+      });
+    });
   });
 }
 


### PR DESCRIPTION
## Description
Adds `acdc_source` to `response.extra` to indicate the source of the response.

Fixes #5

## Changes
- Modified `AcdcCacheInterceptor` to set `acdc_source` to:
  - `'cache'`: Standard cache hit
  - `'network'`: Standard network response
  - `'cache_stale'`: SWR stale emission
  - `'network_fresh'`: SWR fresh emission
- Update documentation in `doc/caching.md`
- Added tests in `test/interceptors/cache_interceptor_test.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for identifying response sources through metadata ('cache', 'network', 'cache_stale', 'network_fresh'), including usage examples and conditional UI patterns.

* **New Features**
  * Responses now consistently include source metadata across cache, network, and SWR scenarios, enabling apps to determine response origin.

* **Tests**
  * Added tests validating response source metadata across network, cache hit, and SWR scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->