### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,58 @@
-## Unreleased
+## 0.3.0 - 2026-02-14
 
 > [!IMPORTANT]
-> This release introduces breaking changes to cache behavior for safer defaults.
+> This release introduces breaking changes to cache behavior for safer defaults and includes significant improvements to error handling, testing, and token management.
+
+### Breaking Changes
 
 *   **BREAKING**: Changed default `staleIfErrorCodes` from `[401, 403]` to `[500, 502, 503, 504]` (server errors only). This prevents authentication failures from being masked by stale cache. If you relied on the previous behavior, explicitly set `staleIfErrorCodes: [401, 403, 500, 502, 503, 504]` in your `CacheConfig`.
-*   **NEW**: Added configurable `staleIfErrorCodes` field to `CacheConfig` to customize which HTTP status codes trigger stale cache serving when `staleIfError` is enabled.
+
+### Features
+
+*   Added configurable `staleIfErrorCodes` field to `CacheConfig` to customize which HTTP status codes trigger stale cache serving when `staleIfError` is enabled.
+*   Convert `badCertificate` exceptions to `AcdcSecurityException` for consistent error handling.
+*   Exported `AcdcSecurityException` from public API for better error handling capabilities.
+
+### Improvements
+
+*   Improved SocketException handling and aligned TokenProvider contract implementations.
+*   Made `refreshNow()` actually force a refresh regardless of token expiry status.
+*   Clarified and enforced consistent `setTokens()` partial update semantics.
+*   Replaced string-based network error detection with type checking for more reliable network error detection.
+*   Made `LoggingInterceptor._isLogging` flag instance-scoped to prevent race conditions.
+*   Fixed cache clearing for user-isolated cache entries with `clearCacheForUrl()`.
+*   Improved clock skew parsing to use `HttpDate.parse()` for RFC 1123 Date header parsing.
+
+### Documentation
+
+*   Clarified `refreshNow()` forced refresh behavior and exception handling.
+*   Corrected documentation and example code inconsistencies.
+*   Clarified that `maxSize` is not enforced and deprecated the parameter.
+*   Fixed git hook setup instructions.
+*   Corrected example to use proper API.
+
+### Testing
+
+*   Improved `PinningHttpClient` test coverage from 12.5% to 100%.
+*   Added comprehensive test coverage for `AcdcSecurityException.fromDioException`.
+*   Added unit tests for `forceRefresh()` method.
+*   Added unit test for SocketException type checking.
+*   Improved overall project coverage to 93.56%.
+
+### Bug Fixes
+
+*   Fixed incorrect assertion in `refreshNow` test.
+*   Removed unreachable badCertificate case from `_isNetworkError`.
+*   Fixed `clearCacheForUrl()` to properly delete user-isolated cache entries.
+*   Removed dead ternary in CachePolicy assignment.
+*   Unified maxStale logic in dual CacheOptions objects.
+
+### Maintenance
+
+*   Removed macOS and Windows test jobs from CI.
+*   Updated dependencies: `actions/checkout` v4→v6, `codecov/codecov-action` v4→v5.
+*   Excluded test certificates from secret scanning.
+*   Removed unnecessary HTTP logging from test servers.
 
 ## 0.2.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_acdc
 description: Zero-config HTTP client for Flutter with built-in auth, caching, logging, and error handling. Integrates with OpenAPI-generated code.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/jhosm/Dart-ACDC
 homepage: https://github.com/jhosm/Dart-ACDC
 issue_tracker: https://github.com/jhosm/Dart-ACDC/issues


### PR DESCRIPTION
# Release v0.3.0

> [!IMPORTANT]
> This release introduces breaking changes to cache behavior for safer defaults and includes significant improvements to error handling, testing, and token management.

## Breaking Changes

- **BREAKING**: Changed default `staleIfErrorCodes` from `[401, 403]` to `[500, 502, 503, 504]` (server errors only). This prevents authentication failures from being masked by stale cache. If you relied on the previous behavior, explicitly set `staleIfErrorCodes: [401, 403, 500, 502, 503, 504]` in your `CacheConfig`.

## Features

- Added configurable `staleIfErrorCodes` field to `CacheConfig` to customize which HTTP status codes trigger stale cache serving when `staleIfError` is enabled.
- Convert `badCertificate` exceptions to `AcdcSecurityException` for consistent error handling.
- Exported `AcdcSecurityException` from public API for better error handling capabilities.

## Improvements

- Improved SocketException handling and aligned TokenProvider contract implementations.
- Made `refreshNow()` actually force a refresh regardless of token expiry status.
- Clarified and enforced consistent `setTokens()` partial update semantics.
- Replaced string-based network error detection with type checking for more reliable network error detection.
- Made `LoggingInterceptor._isLogging` flag instance-scoped to prevent race conditions.
- Fixed cache clearing for user-isolated cache entries with `clearCacheForUrl()`.
- Improved clock skew parsing to use `HttpDate.parse()` for RFC 1123 Date header parsing.

## Documentation

- Clarified `refreshNow()` forced refresh behavior and exception handling.
- Corrected documentation and example code inconsistencies.
- Clarified that `maxSize` is not enforced and deprecated the parameter.
- Fixed git hook setup instructions.
- Corrected example to use proper API.

## Testing

- Improved `PinningHttpClient` test coverage from 12.5% to 100%.
- Added comprehensive test coverage for `AcdcSecurityException.fromDioException`.
- Added unit tests for `forceRefresh()` method.
- Added unit test for SocketException type checking.
- Improved overall project coverage to 93.56%.

## Bug Fixes

- Fixed incorrect assertion in `refreshNow` test.
- Removed unreachable badCertificate case from `_isNetworkError`.
- Fixed `clearCacheForUrl()` to properly delete user-isolated cache entries.
- Removed dead ternary in CachePolicy assignment.
- Unified maxStale logic in dual CacheOptions objects.

## Maintenance

- Removed macOS and Windows test jobs from CI.
- Updated dependencies: `actions/checkout` v4→v6, `codecov/codecov-action` v4→v5.
- Excluded test certificates from secret scanning.
- Removed unnecessary HTTP logging from test servers.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 0.3.0 Release Notes

* **Breaking Changes**
  * Default error codes for stale content handling changed from [401, 403] to [500, 502, 503, 504]

* **New Features**
  * Added configurable error code handling for stale content scenarios
  * Enhanced security exception handling and exports

* **Improvements**
  * Improved robustness with better socket exception handling, token management, and network error detection
  * Enhanced cache management and documentation clarity

* **Bug Fixes**
  * Fixed refresh behavior and cache entry handling issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->